### PR TITLE
Allow users to specify compilation priority for hosts

### DIFF
--- a/src/plugins/SoftwareGenerator/SoftwareGenerator.js
+++ b/src/plugins/SoftwareGenerator/SoftwareGenerator.js
@@ -110,6 +110,7 @@ define([
 
         // which architectures did the user ask us to compile on?
         self.selectedArchitectures = [];
+	self.archPriorities = {};
         Object.keys(currentConfig).map(function(k) {
             if (k.indexOf('_ARCH_SELECTION') > -1) {
                 var arch = k.replace('_ARCH_SELECTION', '');
@@ -117,7 +118,13 @@ define([
                 if (isSelected) {
                     self.selectedArchitectures.push( arch );
                 }
-            }
+            } else if (k.indexOf('_HOST_SELECTION') > -1) {
+                var arch = k.replace('_HOST_SELECTION', '');
+                var orderedHosts = currentConfig[k];
+                if (Array.isArray(orderedHosts)) {
+                    self.archPriorities[ arch ] = orderedHosts;
+                }
+	    }
         });
         // make sure we don't try to compile if we don't have architectures
         self.compileCode = self.selectedArchitectures.length && self.compileCode;

--- a/src/plugins/SoftwareGenerator/configWidget.js
+++ b/src/plugins/SoftwareGenerator/configWidget.js
@@ -108,6 +108,7 @@ define([
                         'Architecture': self.core.getAttribute(h, 'Architecture'),
                         'Device ID': self.core.getAttribute(h, 'Device ID'),
 			'name': self.core.getAttribute(h, 'name'),
+			'path': self.core.getPath(h)
                     };
                     var arch = utils.getDeviceType( host );
 		    if (!archs[arch]) {
@@ -152,7 +153,7 @@ define([
 	    hostTempl.name = arch + '_HOST_SELECTION';
 	    hostTempl.displayName = arch + " Compilation Priority";
 	    hostTempl.description = "Sort the "+arch+" hosts for compilation priority, top to bottom.";
-	    hostTempl.valueItems = architectures[arch].map(host => host.name);
+	    hostTempl.valueItems = architectures[arch].map(host => `${host.path}::${host.name}`);
 	    archConfig.push( hostTempl );
         });
 

--- a/src/plugins/SoftwareGenerator/configWidget.js
+++ b/src/plugins/SoftwareGenerator/configWidget.js
@@ -101,17 +101,19 @@ define([
                 return Q.all(tasks);
             })
             .then(function(hostList) {
-                var archs = [];
+                var archs = {}
                 hostList = _.flatten(hostList);
                 hostList.map(function(h) {
                     var host = {
                         'Architecture': self.core.getAttribute(h, 'Architecture'),
                         'Device ID': self.core.getAttribute(h, 'Device ID'),
+			'name': self.core.getAttribute(h, 'name'),
                     };
                     var arch = utils.getDeviceType( host );
-                    if (archs.indexOf(arch) == -1) {
-                        archs.push( arch );
-                    }
+		    if (!archs[arch]) {
+			archs[arch] = [];
+		    }
+		    archs[arch].push(host);
                 });
                 return archs;
             });
@@ -130,11 +132,28 @@ define([
             "readOnly": false
         };
 
-        architectures.map(function(arch) {
+        var hostSelectorTempl = {
+	    "name": "",
+	    "displayName": "",
+	    "description": "",
+	    "value": "",
+	    "valueType": "sortable",
+	    "valueItems": [],
+            "readOnly": false
+        };
+
+        Object.keys(architectures).map(function(arch) {
             var archTempl = Object.assign({}, templ);
             archTempl.name = arch + '_ARCH_SELECTION';
             archTempl.displayName = 'Compile on ' + arch;
             archConfig.push( archTempl );
+
+	    var hostTempl = Object.assign({}, hostSelectorTempl);
+	    hostTempl.name = arch + '_HOST_SELECTION';
+	    hostTempl.displayName = arch + " Compilation Priority";
+	    hostTempl.description = "Sort the "+arch+" hosts for compilation priority, top to bottom.";
+	    hostTempl.valueItems = architectures[arch].map(host => host.name);
+	    archConfig.push( hostTempl );
         });
 
         return archConfig;


### PR DESCRIPTION
If similar architectures have different performance characteristics - the user can sort the hosts per architecture to tell ROSMOD their preferred host for compilation.